### PR TITLE
Very quick and easy method of arguments

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -417,8 +417,12 @@ class CommandHandler extends AkairoHandler {
         try {
             interaction.defer(false)
             interaction.reply = interaction.editReply
+            const convertedOptions = {}
+            for (const option of interaction.options) {
+                convertedOptions[option.name] = option
+            }
             this.emit("slashStarted", interaction, command);
-            await command.execSlash(interaction)
+            await command.execSlash(interaction, convertedOptions)
         } catch (err) {
             this.emit("slashError", err, interaction, command)
         }


### PR DESCRIPTION
Just converts `interaction.options` to `Record<string, CommandInteractionOption>` and passes it as an argument to execSlash, no parsing tho