### PR TITLE
Add permissions check and fix some eslint issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,57 +14,8 @@
   </p>
 </div>
 
-### Has slash commands
-
-For slash commands to work you need to add execslash to the command and when it recieves a command it will try and run it
-
-new events:
- * slashError
- * slashBlocked
-    * owner
-    * superuser
- * slashStarted
- * slashNotFound
- * slashGuildOnly
-
-for more info about these events view the [source code](https://github.com/SkyBlockDev/discord-akairo/blob/master/src/struct/commands/CommandHandler.js#L396)
-
-Also if someone wants to add slash commands and superuseronly to the test
-
-examples:
-```ts
-import { Command } from "discord-akairo";
-import type { CommandInteractionk, Message } from "discord.js";
-export default class AvatarCommand extends Command {
-    public constructor() {
-        super("avatar", {
-            aliases: ["avatar"],
-            options: [
-                {
-                    type: 6,
-                    name: "user",
-                    description: "User you want the avatar of",
-                    required: false,
-                }
-            ]
-        });
-    }
-    exec(message: Message) {
-        message.reply("This also works")
-    }
-    async execSlash(interaction: CommandInteraction) {
-        const member = message.options[0]?.user ?? message.user;
-        return message.reply(
-            this.client.util
-                .embed()
-                .setTitle(`${member.username}'s Avatar`)
-                .setURL(member.displayAvatarURL({ format: "png", size: 512, dynamic: true }))
-                .setColor(this.client.colors.green)
-                .setImage(member.displayAvatarURL({ format: "png", size: 512, dynamic: true }))
-        );
-    }
-}
-```
+### Changes in this fork of akairo
+Please see [this file](/blob/master/docs/general/updates.md) for a list of changes in this fork vs normal akairo
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 </div>
 
 ### Changes in this fork of akairo
-Please see [this file](/blob/master/docs/general/updates.md) for a list of changes in this fork vs normal akairo
+Please see [this file](/docs/general/updates.md) for a list of changes in this fork vs normal akairo
 
 ## Features
 

--- a/docs/general/updates.md
+++ b/docs/general/updates.md
@@ -12,6 +12,8 @@ New slash command related events:
  * slashNotFound
  * slashGuildOnly
  * slashMissingPermissions
+    * user
+    * client
 
 For more info about these events view the [source code](https://github.com/SkyBlockDev/discord-akairo/blob/master/src/struct/commands/CommandHandler.js#L396). If you don't want to do that, you can safely assume that they are the exact same as their non-slash versions, execpt all `Message` arguments are changed to `CommandInteraction`.
 
@@ -44,9 +46,9 @@ export default class AvatarCommand extends Command {
 Note that this example assumes a few things.
 1. You already have a registered slash command called `avatar`
 2. The registered command has one option named `user`, and
-   1. The type is User
-   2. Required is `false`
-<br>
+    1. The type is `6` (enum value for user)
+    2. Required is `false`
+
 You can do this all manually using something like an eval command, or just making the http requests to the discord api yourself, or making it automated, but just keep in mind that the library won't register anything for you.
 
 ## Superusers

--- a/docs/general/updates.md
+++ b/docs/general/updates.md
@@ -1,0 +1,53 @@
+# Changes in this fork of akairo
+
+## Slash commands
+For slash commands to work you need to add `execSlash` to the command, and when it recieves a slash command it will run `execSlash`.
+
+New slash command related events:
+ * slashError
+ * slashBlocked
+    * owner
+    * superuser
+ * slashStarted
+ * slashNotFound
+ * slashGuildOnly
+ * slashMissingPermissions
+
+For more info about these events view the [source code](https://github.com/SkyBlockDev/discord-akairo/blob/master/src/struct/commands/CommandHandler.js#L396). If you don't want to do that, you can safely assume that they are the exact same as their non-slash versions, execpt all `Message` arguments are changed to `CommandInteraction`.
+
+Slash command example:
+```ts
+import { Command } from "discord-akairo";
+import { CommandInteraction, CommandInteractionOption, Message, User } from "discord.js";
+export default class AvatarCommand extends Command {
+    public constructor() {
+        super("avatar", {
+            aliases: ["avatar"]
+        });
+    }
+    exec(message: Message) {
+        message.reply("This also works")
+    }
+    async execSlash(interaction: CommandInteraction, { user }: { user?: CommandInteractionOption } ) {
+        const member = user?.user ?? interaction.user;
+        return message.reply(
+            this.client.util
+                .embed()
+                .setTitle(`${member.username}'s Avatar`)
+                .setURL(member.displayAvatarURL({ format: "png", size: 512, dynamic: true }))
+                .setColor(this.client.colors.green)
+                .setImage(member.displayAvatarURL({ format: "png", size: 512, dynamic: true }))
+        );
+    }
+}
+```
+Note that this example assumes a few things.
+1. You already have a registered slash command called `avatar`
+2. The registered command has one option named `user`, and
+   1. The type is User
+   2. Required is `false`
+<br>
+You can do this all manually using something like an eval command, or just making the http requests to the discord api yourself, or making it automated, but just keep in mind that the library won't register anything for you.
+
+## Superusers
+Superusers are included, no documentation yet though.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,7 +5,7 @@ declare module 'discord-akairo' {
         MessageAdditions, MessageEditOptions, MessageOptions, SplitOptions,
         User, UserResolvable, GuildMember,
         Channel, Role, Emoji, Guild,
-        PermissionResolvable, StringResolvable, Snowflake,CommandInteraction
+        PermissionResolvable, StringResolvable, Snowflake, CommandInteraction
     } from 'discord.js';
 
     import { EventEmitter } from 'events';
@@ -174,7 +174,7 @@ declare module 'discord-akairo' {
         public superUserOnly: boolean;
         public prefix?: string | string[] | PrefixSupplier;
         public ratelimit: number;
-        public options: any | any[]
+        public options: any | any[];
         public regex: RegExp | RegexSupplier;
         public typing: boolean;
         public userPermissions: PermissionResolvable | PermissionResolvable[] | MissingPermissionSupplier;

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -1,7 +1,7 @@
 const AkairoError = require('../../util/AkairoError');
 const AkairoHandler = require('../AkairoHandler');
 const { BuiltInReasons, CommandHandlerEvents } = require('../../util/Constants');
-const { Collection, CommandInteraction } = require('discord.js');
+const { Collection } = require('discord.js');
 const Command = require('./Command');
 const CommandUtil = require('./CommandUtil');
 const Flag = require('./Flag');
@@ -235,7 +235,7 @@ class CommandHandler extends AkairoHandler {
                     if (this.handleEdits) this.handle(m);
                 });
             }
-            this.client.on('interaction', async i => {
+            this.client.on('interaction', i => {
                 this.handleSlash(i);
             });
         });
@@ -394,62 +394,69 @@ class CommandHandler extends AkairoHandler {
         }
     }
 
-	/**
+    /**
      * Handles a slash command.
      * @param {CommandInteraction} interaction - Interaction to handle.
      * @returns {Promise<?boolean>}
      */
     async handleSlash(interaction) {
-        if (!interaction.isCommand()) return;
+        if (!interaction.isCommand()) return false;
 
         if (!interaction.guildID) {
-            return this.emit("slashGuildOnly", interaction)
+            this.emit('slashGuildOnly', interaction);
+            return false;
         }
 
         const command = this.modules.get(interaction.commandName);
 
         if (!command) {
-            return this.emit("slashNotFound", interaction)
+            this.emit('slashNotFound', interaction);
+            return false;
         }
 
         if (command.ownerOnly && !this.client.isOwner(interaction.user)) {
-            return this.emit("slashBlocked", interaction, command, "owner")
-
+            this.emit('slashBlocked', interaction, command, 'owner');
+            return false;
         }
         if (command.superUserOnly && !this.client.isSuperUser(interaction.user)) {
-            return this.emit("slashBlocked", interaction, command, "superuser")
+            this.emit('slashBlocked', interaction, command, 'superuser');
+            return false;
         }
-		const userPermissions = interaction.channel.permissionsFor(interaction.member).toArray()
-		const userMissingPermissions = command.userPermissions.filter(p => !userPermissions.includes(p))
-		if (
-			command.userPermissions &&
-			command.userPermissions.length > 0 &&
-			userMissingPermissions.length > 0
-		) {
-			return this.emit("slashMissingPermissions", interaction, command, "user", userMissingPermissions)
-		}
+        const userPermissions = interaction.channel.permissionsFor(interaction.member).toArray();
+        const userMissingPermissions = command.userPermissions.filter(p => !userPermissions.includes(p));
+        if (
+            command.userPermissions
+			&& command.userPermissions.length > 0
+			&& userMissingPermissions.length > 0
+        ) {
+            this.emit('slashMissingPermissions', interaction, command, 'user', userMissingPermissions);
+            return false;
+        }
 
-		const clientPermissions = interaction.channel.permissionsFor(interaction.guild.me).toArray()
-		const clientMissingPermissions = command.clientPermissions.filter(p => !clientPermissions.includes(p))
-		if (
-			command.clientPermissions &&
-			command.clientPermissions.length > 0 &&
-			clientMissingPermissions.length > 0
-		) {
-			return this.emit("slashMissingPermissions", interaction, command, "client", clientMissingPermissions)
-		}
+        const clientPermissions = interaction.channel.permissionsFor(interaction.guild.me).toArray();
+        const clientMissingPermissions = command.clientPermissions.filter(p => !clientPermissions.includes(p));
+        if (
+            command.clientPermissions
+			&& command.clientPermissions.length > 0
+			&& clientMissingPermissions.length > 0
+        ) {
+            this.emit('slashMissingPermissions', interaction, command, 'client', clientMissingPermissions);
+            return false;
+        }
 
         try {
-            interaction.defer(false)
-            interaction.reply = interaction.editReply
-            const convertedOptions = {}
+            interaction.defer(false);
+            interaction.reply = interaction.editReply;
+            const convertedOptions = {};
             for (const option of interaction.options) {
-                convertedOptions[option.name] = option
+                convertedOptions[option.name] = option;
             }
-            this.emit("slashStarted", interaction, command);
-            await command.execSlash(interaction, convertedOptions)
+            this.emit('slashStarted', interaction, command);
+            await command.execSlash(interaction, convertedOptions);
+            return true;
         } catch (err) {
-            this.emit("slashError", err, interaction, command)
+            this.emit('slashError', err, interaction, command);
+            return false;
         }
     }
     /**


### PR DESCRIPTION
- Checks both `userPermissions` and `clientPermissions` with slash commands
- Adds `slashMissingPermissions` event (duplicate of `missingPermissions` except with `CommandInteraction` instead of `Message` for `message` parameter)
- Fixed some eslint issues
- Make documentation for changes in the fork better

Note: hasn't been tested yet