### PR TITLE
Fixed broken link

### DIFF
--- a/docs/general/updates.md
+++ b/docs/general/updates.md
@@ -49,7 +49,7 @@ Note that this example assumes a few things.
     1. The type is `6` (enum value for user)
     2. Required is `false`
 
-You can do this all manually using something like an eval command, or just making the http requests to the discord api yourself, or making it automated, but just keep in mind that the library won't register anything for you. Read [this](https://discord.js.org/#/docs/main/master/examples/commands) for how to create/edit/delete slash commands in discord.js.
+You can do this all manually using something like an eval command, or just making the http requests to the discord api yourself, or making it automated, but just keep in mind that the library won't register anything for you. Read [this](https://github.com/MatteZ02/discord-interactions) for how to create/edit/delete slash commands in discord.js.
 
 ## Superusers
 Superusers are included, no documentation yet though.


### PR DESCRIPTION
discord.js link for slash commands was unavailable, same for official discord.js v13 update changelongs.
this was the best i could find:
https://github.com/MatteZ02/discord-interactions