### PR TITLE
Fix error Cannot mix BigInt and other types, use explicit conversions

### DIFF
--- a/src/struct/ClientUtil.js
+++ b/src/struct/ClientUtil.js
@@ -337,7 +337,7 @@ class ClientUtil {
         const resolved = [];
 
         for (const key of Object.keys(Permissions.FLAGS)) {
-            if (number & Permissions.FLAGS[key]) resolved.push(key);
+            if (BigInt(number) & Permissions.FLAGS[key]) resolved.push(key);
         }
 
         return resolved;


### PR DESCRIPTION
There is an error when using this method, apparently only using discord.js v13