### PR TITLE
feat(CommandHandler/onlyNsfw)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -372,6 +372,7 @@ declare module "discord-akairo" {
 		public parse(message: Message, content: string): Promise<Flag | any>;
 		public reload(): this;
 		public remove(): this;
+		public onlyNsfw: boolean
 	}
 
 	export class CommandHandler extends AkairoHandler {
@@ -952,6 +953,7 @@ declare module "discord-akairo" {
 			| MissingPermissionSupplier;
 		quoted?: boolean;
 		slashEmphemeral?: boolean;
+		onlyNsfw?:boolean
 	}
 
 	export interface CommandHandlerOptions extends AkairoHandlerOptions {

--- a/src/struct/commands/Command.js
+++ b/src/struct/commands/Command.js
@@ -15,6 +15,7 @@ class Command extends AkairoModule {
 		super(id, { category: options.category });
 
 		const {
+			onlyNsfw = false,
 			slash = false,
 			aliases = [],
 			args = this.args || [],
@@ -66,6 +67,12 @@ class Command extends AkairoModule {
 					args.map(arg => [arg.id, new Argument(this, arg)])
 			  )
 			: args.bind(this);
+
+		/**
+		 * Usable only in this NSFW Channels.
+		 * @type {boolean}
+		 */
+		 this.onlyNsfw = Boolean(onlyNsfw);
 
 		/**
 		 * Usable only in this channel type.
@@ -281,6 +288,7 @@ module.exports = Command;
  * @prop {boolean} [ownerOnly=false] - Whether or not to allow client owner(s) only.
  * @prop {boolean} [superUserOnly=false] - Whether or not to allow client SuperUsers(s) only.
  * @prop {boolean} [typing=false] - Whether or not to type in channel during execution.
+ * @prop {boolean} [onlyNsfw=false] - Whether or not to type in channel during execution.
  * @prop {boolean} [editable=true] - Whether or not message edits will run this command.
  * @prop {number} [cooldown] - The command cooldown in milliseconds.
  * @prop {number} [ratelimit=1] - Amount of command uses allowed until cooldown.

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -1015,7 +1015,7 @@ class CommandHandler extends AkairoHandler {
 			message.channel.startTyping();
 		}
 		if (command.onlyNsfw && !message.channel.nsfw) {
-			this.handler.emit("notNSFW", message)
+			this.emit("notNSFW", message)
 		}
 		try {
 			this.emit(CommandHandlerEvents.COMMAND_STARTED, message, command, args);

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -1014,7 +1014,9 @@ class CommandHandler extends AkairoHandler {
 		if (command.typing) {
 			message.channel.startTyping();
 		}
-
+		if (command.onlyNsfw && !message.channel.nsfw) {
+			this.handler.emit("notNSFW", message)
+		}
 		try {
 			this.emit(CommandHandlerEvents.COMMAND_STARTED, message, command, args);
 			const ret = await command.exec(message, args);

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -1015,7 +1015,8 @@ class CommandHandler extends AkairoHandler {
 			message.channel.startTyping();
 		}
 		if (command.onlyNsfw && !message.channel.nsfw) {
-			return this.emit("notNSFW", message, command)
+			return this.emit("notNsfw", message, command)
+			
 		}
 		try {
 			this.emit(CommandHandlerEvents.COMMAND_STARTED, message, command, args);

--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -1015,7 +1015,7 @@ class CommandHandler extends AkairoHandler {
 			message.channel.startTyping();
 		}
 		if (command.onlyNsfw && !message.channel.nsfw) {
-			this.emit("notNSFW", message)
+			return this.emit("notNSFW", message, command)
 		}
 		try {
 			this.emit(CommandHandlerEvents.COMMAND_STARTED, message, command, args);


### PR DESCRIPTION
After looking at a comment in Akairo Discord of a user wanting to add a `onlyNsfw: true` property to the Command class I decided it was a nice feature to have and since it didn't look too hard I got my hands into it.

basically if `onlyNsfw: true` but the channel is not NSFW the CommandHandler will emit the notNsfw event and pass the message object and the command ran so the user can listen to it and send custom messages, log it etc

I decided to Pull Request it to your fork as it is more updated than Akairo official repo and since I myself use it. If you need anything changed lmk, tested everything except listening for the event (It's late, will do tomorrow if I remember) and it worked, results are in Akairo discord General chatroom.