### PR TITLE
Emits the commandBlocked event for non nsfw channels

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -1122,7 +1122,7 @@ class CommandHandler extends AkairoHandler {
 		}
 
 		if (command.onlyNsfw && !message.channel.nsfw) {
-			this.emit(CommandHandlerEvents.COMMAND_LOCKED_NSFW, message, command);
+			this.emit(CommandHandlerEvents.COMMAND_BLOCKED, message, command, 'notNsfw');
 			return;
 		}
 

--- a/src/util/Constants.js
+++ b/src/util/Constants.js
@@ -72,7 +72,6 @@ module.exports = {
 		COMMAND_CANCELLED: "commandCancelled",
 		COMMAND_LOCKED: "commandLocked",
 		COMMAND_INVALID: "commandInvalid",
-		COMMAND_LOCKED_NSFW: "commandLockedNsfw",
 		MISSING_PERMISSIONS: "missingPermissions",
 		COOLDOWN: "cooldown",
 		IN_PROMPT: "inPrompt",


### PR DESCRIPTION
Emits the commandBlocked event with the reason `notNsfw` when `onlyNsfw` is set to true in Command options instead of a new event.