### PR TITLE
fix: Slash command doesn't run if there are no options

### DIFF
--- a/src/struct/commands/CommandHandler.js
+++ b/src/struct/commands/CommandHandler.js
@@ -619,11 +619,13 @@ class CommandHandler extends AkairoHandler {
 			}
 
 			const convertedOptions = {};
-			for (const option of command.slashOptions) {
-				convertedOptions[option.name] = interaction.options.get(
-					option.name,
-					option.required || false
-				)?.value;
+			if (command.slashOptions) {
+				for (const option of command.slashOptions) {
+					convertedOptions[option.name] = interaction.options.get(
+						option.name,
+						option.required || false
+					)?.value;
+				}	
 			}
 
 			let key;


### PR DESCRIPTION
Error was that it couldn't iterate through undefined, which was slashOptions. Simply adding a conditional statement fixed this issue, and now slash commands work with and without selected options.

This may have been an issue on my end, but adding this code seemed to fix my issue.